### PR TITLE
ChangeR 26.08.0: inc, datatools, update ignore files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,23 +1,47 @@
-^.+\.Rproj$
-^libWin$
-^libMac$
-^lib$
-^libLinux$
-^Dockerfile$
-^covr$
-^deps$
-^Jenkinsfile$
-^JenkinsfileMPI$
-^bin$
-^LICENSE\.md$
-^deploy\.sh$
-^\..*$
+
+# RStudio / IDE files
+^.*\.Rproj$
 ^\.Rproj\.user$
-^inst/data$
+^\.vscode$
+
+# Local/user config
+^\.Rprofile$
+^\.Renviron$
+^\.env$
+
+# Version control / GitHub
+^\.git$
+^\.gitignore$
+^\.github$
+
+# CI / deployment / containers
+^Dockerfile$
+^\.dockerignore$
+^Jenkinsfile$
+^deploy\.sh$
+
+# pkgdown site and config
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
-^\.github$
+
+# Local dependency/vendor libraries
+^lib$
+^libWin$
+^libMac$
+^libLinux$
+^deps$
+
+# Build/test artifacts
+^covr$
+^bin$
+^.*\.tar\.gz$
+^.*\.Rcheck$
+
+# Non-package license/readme variants
+^LICENSE\.md$
+
+^inst/data$
 ^inst/app/predefinedModels/
 ^inst/app/dataQueries/
 ^tests/testthat/testdata_large/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,64 @@
-libLinux/*
-libWin/*
+# Version control
 .git
+.gitignore
+.github/
+
+# RStudio / IDE files
+.Rproj.user/
+*.Rproj
+.vscode/
+
+# Local R/session config
 .Rprofile
+.Rhistory
+.RData
+.Ruserdata
+.Renviron
+
+# Secrets / local env files
+.env
+.env.*
+!.env.example
+
+# Local dependency libraries
+lib/
+libLinux/
+libWin/
+libMac/
+deps/
+
+# Generated package/build artifacts
+*.tar.gz
+*.Rcheck/
+check/
+Meta/
+src/*.o
+src/*.so
+src/*.dll
+
+# Generated docs/sites
+docs/
+pkgdown/
+inst/doc/
+
+# Coverage/test/dev artifacts
+.Rcoverage
+covr/
+
+# CI/deployment files not needed inside image
 Jenkinsfile
+.github/
+deploy.sh
+
+# Docker metadata not needed after build starts
 Dockerfile
+.dockerignore
+
+# OS/editor temp files
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+*.bak
+*.swp
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,48 @@
-.Rproj.user
+# R session/user state
 .Rhistory
 .RData
 .Ruserdata
-inst/doc
-docs
+.Rproj.user/
+
+# Local environment/config
+.Renviron
+.env
+.env.*
+!.env.example
+
+# R package build/check artifacts
+*.tar.gz
+*.Rcheck/
+check/
+Meta/
+src/*.o
+src/*.so
+src/*.dll
+
+# Generated documentation/sites
+docs/
+inst/doc/
+
+# Test/coverage artifacts
+.Rcoverage
+covr/
+
+# Local dependency libraries
+lib/
+libLinux/*
+libWin/*
+libMac/*
+!libLinux/.gitignore
+!libWin/.gitignore
+!libMac/.gitignore
+
+# Logs and temporary files
+*.log
+*.tmp
+*.bak
+*.swp
+.DS_Store
+Thumbs.db
+
+# Optional IDE/editor config
+.vscode/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ChangeR
 Title: Identify and display change points
-Version: 25.04.0
+Version: 26.08.0
 Authors@R: c(
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut", "cre")),
     person("Runge", "Antonia", email = "antonia.runge@inwt-statistics.de", role = c("aut"))
@@ -11,7 +11,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Imports:
-  DataTools (>= 24.10.0),
+  DataTools (>= 26.08.2),
   DT,
   futile.logger,
   loo,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # ChangeR 26.08.0
 
 ## Updates
--
+- Increased the required DataTools version to the most recent version.
+- Expanded and organized .Rbuildignore, .gitignore, and .dockerignore entries to reduce accidental inclusion of local/CI/build artifacts.
 
 # ChangeR 25.04.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# ChangeR 26.08.0
+
+## Updates
+-
+
 # ChangeR 25.04.0
 
 ## New Features


### PR DESCRIPTION
# ChangeR 26.08.0

## Updates
- Increased the required DataTools version to the most recent version.
- Expanded and organized .Rbuildignore, .gitignore, and .dockerignore entries to reduce accidental inclusion of local/CI/build artifacts.